### PR TITLE
Improve responsive image sizing for cover images

### DIFF
--- a/wordpress/wp-content/themes/les-verts/lib/twig/functions/image-filters.php
+++ b/wordpress/wp-content/themes/les-verts/lib/twig/functions/image-filters.php
@@ -96,7 +96,6 @@ class ImageFilters extends AbstractExtension {
             'src' => esc_url($src),
             'srcset' => $srcset,        // Standard srcset for non-lazy images
             'data-srcset' => $srcset,   // Data-srcset for lazy loading JavaScript
-            'sizes' => '100vw',
             'loading' => 'lazy',
             'alt' => !empty($attr['alt']) ? $attr['alt'] : ''
         ];
@@ -105,6 +104,16 @@ class ImageFilters extends AbstractExtension {
         $attributes['data-focal-point'] = $focal_point;
 
         $attributes = array_merge($attributes, $attr);
+
+        // For cover images (object-fit: cover), use 200vw to account for ~2x zoom from aspect ratio mismatch
+        // This ensures browser downloads high enough resolution before cropping
+        // Set this AFTER merge to prevent it from being overwritten
+        $sizes_value = !empty($attr['data-cover']) ? '200vw' : '100vw';
+        $attributes['sizes'] = $sizes_value;
+        $attributes['data-sizes'] = $sizes_value;  // Also set data-sizes for lazy loading script
+
+        // Remove data-cover from final attributes (it's only used for logic, not as HTML attribute)
+        unset($attributes['data-cover']);
 
         $html_attributes = [];
         foreach ($attributes as $name => $value) {

--- a/wordpress/wp-content/themes/les-verts/lib/twig/functions/image-handling.php
+++ b/wordpress/wp-content/themes/les-verts/lib/twig/functions/image-handling.php
@@ -87,8 +87,8 @@ function les_verts_image_handling_setup() {
     add_image_size('wpseo-opengraph', 1200, 630, true);
 
     // Set default image quality
-    add_filter('jpeg_quality', function() { return 85; });
-    add_filter('wp_editor_set_quality', function() { return 85; });
+    add_filter('jpeg_quality', function() { return 90; });
+    add_filter('wp_editor_set_quality', function() { return 90; });
 }
 
 /**
@@ -141,8 +141,8 @@ add_filter('get_twig', function($twig) {
 
     $twig->addFilter(
         new TwigFilter( 'get_timber_image_responsive',
-            function (Environment $env, $image, $size = 'medium') use ($image_filters) {
-                return $image_filters->getTimberImageResponsive($env, $image, $size);
+            function (Environment $env, $image, $size = 'medium', $attr = []) use ($image_filters) {
+                return $image_filters->getTimberImageResponsive($env, $image, $size, $attr);
             },
             ['needs_environment' => true]
         )

--- a/wordpress/wp-content/themes/les-verts/style.css
+++ b/wordpress/wp-content/themes/les-verts/style.css
@@ -2,7 +2,7 @@
  * Theme Name: Les Verts
  * Description: Custom theme for the GREENS of Switzerland. Designed by superhuit.ch, built by gruene.ch on top of superhuit's stack.
  * Author: superhuit.ch & gruene.ch
- * Version: 0.42.0
+ * Version: 0.42.2
  * Requires PHP: 7.4
  * Requires at least: 5.0
  * Theme URI: https://github.com/grueneschweiz/2018.gruene.ch/

--- a/wordpress/wp-content/themes/les-verts/styleguide/src/components/atoms/a-image/a-image-cover.js
+++ b/wordpress/wp-content/themes/les-verts/styleguide/src/components/atoms/a-image/a-image-cover.js
@@ -22,7 +22,6 @@ export default class AImageCover extends BaseView {
 		super.bind();
 
 		this.on( 'afterReplaceImage', () => {
-			this.setSizes();
 			this.objectFit();
 		} );
 	}
@@ -74,16 +73,5 @@ export default class AImageCover extends BaseView {
 		}
 
 		return '';
-	}
-
-	setSizes() {
-		const img = this.getScopedElement( COVER_IMAGE_SELECTOR );
-		const cDims = this.element.getBoundingClientRect();
-		const cRatio = cDims.width / cDims.height;
-		const iRatio = img.naturalWidth / img.naturalHeight;
-
-		const zoom = iRatio > cRatio ? iRatio / cRatio : cRatio / iRatio;
-
-		img.sizes = Math.min(cDims.width * zoom, window.innerWidth) + 'px';
 	}
 }

--- a/wordpress/wp-content/themes/les-verts/templates/atoms/a-image.twig
+++ b/wordpress/wp-content/themes/les-verts/templates/atoms/a-image.twig
@@ -25,14 +25,14 @@
 
 		{% if not not_lazy %}
 		<noscript>{% endif %}
-			<img {{ img|get_timber_image_responsive(size) }}
+			<img {{ img|get_timber_image_responsive(size, size == 'full-width' or size == 'full' ? {'data-cover': '1'} : {}) }}
 				class="a-image__image{% if not no_crop %} a-image__image--fp a-image__image--fp-{{ focal_point }}{% endif %}"
 				alt="{{ img.alt }}"
 			>
 		{% if not not_lazy %}</noscript>
 		<div class="a-image__lazy-wrapper">
 			<img src="{{ img.src }}"
-				{{ img|get_timber_image_responsive(size) }}
+				{{ img|get_timber_image_responsive(size, size == 'full-width' or size == 'full' ? {'data-cover': '1'} : {}) }}
 					 class="a-image__image a-image__image--lazy{% if no_crop %} a-image__image--no-crop{% else %} a-image__image--fp a-image__image--fp-{{ focal_point }}{% endif %}"
 					 alt="{{ img.alt }}" loading="lazy"
 			>


### PR DESCRIPTION
- Increase JPEG quality from 85 to 90 for better image quality
- Add `data-cover` attribute support to detect cover images (object-fit: cover)
- Set `sizes` attribute to `200vw` for cover images to account for ~2x zoom from aspect ratio mismatch
- Remove JavaScript-based dynamic sizes calculation in favor of static sizing
